### PR TITLE
Add extra config in the wordpress container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       WORDPRESS_DEBUG: 1
       WORDPRESS_CONFIG_EXTRA: |
         define( 'SCRIPT_DEBUG', true );
+        define('WP_SITEURL', 'http://' . $$_SERVER['HTTP_HOST']);
+        define('WP_HOME',    'http://' . $$_SERVER['HTTP_HOST']);
     volumes:
       - wordpress_data:/var/www/html
       - .:/var/www/html/wp-content/plugins/glutenblocks


### PR DESCRIPTION
Fixes # 19

To apply this, the user will need run `docker-compose down -v` and remove the `wordpress` directory. After that, a new run of `docker-compose -f docker-compose.yml -f docker-compose-localdev.yml up` will setup the wordpress container with the extra configs.