### PR TITLE
Make sure the carrouselTimer is compatible with ie11

### DIFF
--- a/packages/jumbotron-carousel/carouselTimer.js
+++ b/packages/jumbotron-carousel/carouselTimer.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
 
-        return null;
+        return -1;
     }
 
     function getNextArrayId() {

--- a/packages/jumbotron-carousel/carouselTimer.js
+++ b/packages/jumbotron-carousel/carouselTimer.js
@@ -1,26 +1,30 @@
-document.addEventListener('DOMContentLoaded', () => {
+if (window.NodeList && !NodeList.prototype.forEach) {
+    NodeList.prototype.forEach = Array.prototype.forEach;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
     const checkboxes = document.querySelectorAll('.gb-carousel__activator');
     const autoplayDelay = document.getElementById('autoplay-value').value * 1000;
     if (autoplayDelay && autoplayDelay > 0) {
         callTimer();
     }
 
-    document.querySelectorAll('.gb-carousel__manual-next').forEach(element => {
-        element.addEventListener('click', (event) => {
+    document.querySelectorAll('.gb-carousel__manual-next').forEach(function (element) {
+        element.addEventListener('click', function (event) {
             event.preventDefault();
             checkboxes[getNextArrayId()].checked = true;
         });
     });
 
-    document.querySelectorAll('.gb-carousel__manual-prev').forEach(element => {
-        element.addEventListener('click', (event) => {
+    document.querySelectorAll('.gb-carousel__manual-prev').forEach(function (element) {
+        element.addEventListener('click', function (event) {
             event.preventDefault();
             checkboxes[getPrevArrayId()].checked = true;
         });
     });
 
     function callTimer() {
-        setTimeout(_=>{
+        setTimeout(function () {
             checkboxes[getNextArrayId()].checked = true;
             callTimer();
         }, autoplayDelay);
@@ -28,9 +32,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function getCurrentArrayId() {
         const currentItem = document.querySelector('.gb-carousel__activator:checked');
-        return Array.from(checkboxes).indexOf(currentItem);
+
+        for (let i = 0; i <= checkboxes.length; i++) {
+            if (checkboxes[i] === currentItem) {
+                return i;
+            }
+        }
+
+        return null;
     }
-    
+
     function getNextArrayId() {
         const currentIndex = getCurrentArrayId();
         return ((currentIndex + 1) > (checkboxes.length - 1)) ? 0 : (currentIndex + 1);


### PR DESCRIPTION
# Description

Make sure the carrouselTimer is compatible with ie11

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
