### PR TITLE
feat: drop support for PHP 8.1 and 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
 
     name: P${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.3"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.11.3"


### PR DESCRIPTION
This pull request updates the minimum supported PHP version for the project and adjusts the test matrix accordingly.

Dependency and CI updates:

* Increased the minimum required PHP version from 8.1 to 8.3 in `composer.json` (`"php": "^8.3"`).
* Updated the GitHub Actions test matrix in `.github/workflows/tests.yml` to remove PHP 8.1 and 8.2, so tests now run only on PHP 8.3, 8.4, and 8.5.

Ref: #59910